### PR TITLE
CSM-16321: corrected readme file at output

### DIFF
--- a/examples/cloudtrail_integration_kinesis/README.md
+++ b/examples/cloudtrail_integration_kinesis/README.md
@@ -20,6 +20,6 @@ This example illustrates how to create a `CloudTrail-Integration` using a Kinesi
 
 | Name | Description |
 | --- | --- |
-| aws_parameters | AWS parameters (ExternalId and IntegrationName) |
+| cloudtrail_role_details | AWS parameters (ExternalId and IntegrationName) |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/cloudtrail_integration_s3/README.md
+++ b/examples/cloudtrail_integration_s3/README.md
@@ -20,6 +20,6 @@ This example illustrates how to create a `CloudTrail-Integration` using S3 bucke
 
 | Name   | Description |
 | --- | --- |
-| aws_parameters | AWS parameters (ExternalId and IntegrationName) |
+| cloudtrail_role_details | AWS parameters (ExternalId and IntegrationName) |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/cspm_integration/README.md
+++ b/examples/cspm_integration/README.md
@@ -18,6 +18,6 @@ This example illustrates how to create a `CSPM-Integration` for Uptycs.
 
 | Name | Description |
 | ---| --- |
-| aws_parameters | AWS parameters (ExternalId and IntegrationName) |
+| cspm_role_details | AWS parameters (ExternalId and IntegrationName) |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cloudtrail_integration/README.md
+++ b/modules/cloudtrail_integration/README.md
@@ -34,9 +34,9 @@ output "aws_parameters" {
 The CloudTrail integration module performs the following actions:
 
 1. Creates a new AWS IAM role using `role_name` with trust relationship policy containing Principal of value of `upt_account_id` and an STS condition that matches the UUID value of `external_id`.
-   
+
    **Note**: It is mandatory that you specify `cloudtrail_bucket_names_list` and/or `cloudtrail_kinesis_stream_arns_list`, else the role is not created.
-   
+
 1. Creates and attaches the inline policy `ReadS3bucketsPolicy` to the new role based on input `cloudtrail_bucket_names_list`.
 1. Creates and attaches the inline policy `SubscribeKinesisStreamPolicy` to the new role based on input `cloudtrail_kinesis_stream_arns_list`.
 1. Attaches permission boundary `permissions_boundary_policy_arn` based on input.
@@ -59,6 +59,6 @@ The CloudTrail integration module performs the following actions:
 
 | Name | Description |
 | --- | --- |
-| aws_parameters | AWS parameters (ExternalId and RoleName) |
+| cloudtrail_role_details | AWS parameters (ExternalId and RoleName) |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cspm_integration/README.md
+++ b/modules/cspm_integration/README.md
@@ -16,7 +16,7 @@ module "cspm-config" {
 }
 
 output "aws_parameters" {
-  value = module.cspm-config.aws_parameters
+  value = module.cspm-config.cspm_role_details
 }
 ```
 

--- a/modules/cspm_integration/README.md
+++ b/modules/cspm_integration/README.md
@@ -47,6 +47,6 @@ The CSPM integration module performs the following actions:
 
 | Name | Description |
 | --- | --- |
-| aws_parameters | AWS parameters (ExternalId and IntegrationName) |
+| cspm_role_details | AWS parameters (ExternalId and IntegrationName) |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
issue : terraform execution failed due to invalid output field on [readme file](https://github.com/uptycslabs/terraform-aws-uptycs/blob/main/modules/cspm_integration/README.md)

fix: corrected output parameters in readme file documentation at Usage 


test
- [X] copy pasting Usage provided at readme and execute terraform

after apply
```
Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

aws_parameters = {
  "ExternalId" = "6bf64888-6e43-4003-9f1b-37181efcf3c2"
  "integrationName" = "UptycsIntegration-cspm"
}

```